### PR TITLE
Fix empty conversation name 

### DIFF
--- a/client/src/components/SidebarChat.js
+++ b/client/src/components/SidebarChat.js
@@ -24,22 +24,8 @@ export default function SidebarChat({ conversation, shouldOpenSidebar, setShould
 
   const numberOfUnreadMessages = getNumberOfUnreadMessages()
 
-  const getConvName = () => {
-    if (conversation.isDM) {
-      const [participant1, participant2] = conversation.participants
-      if (participant1._id === chatData._id) { // is self
-        return participant2.username
-      }
-      return participant1.username
-    }
-    return conversation.name
-  }
-
   const select = () => {
-    setCurrentConversation({
-      ...conversation,
-      name: getConvName()
-    })
+    setCurrentConversation(conversation)
     // setshouldopensdebar(true)
   }
 
@@ -64,7 +50,7 @@ export default function SidebarChat({ conversation, shouldOpenSidebar, setShould
     }}>
       <Avatar sx={{ width: '50px', height: '50px', m: 2 }}/>
       <Box sx={{ alignSelf: 'center', fontWeight:'100' }}>
-        <Typography variant="body1" sx={{ }}>{getConvName()}</Typography>
+        <Typography variant="body1" sx={{ }}>{conversation.name}</Typography>
         <Typography variant="body2" sx={{ color: 'darkgray'}}>{getLastMessage()?.text.length > 10 ? getLastMessage()?.text.substring(1, 10) + '...' : getLastMessage()?.text}</Typography>
       </Box>
       <Box sx={{ pr: 3, flexGrow: 1, display: 'flex', justifyContent: 'end', alignItems: 'center'}}>

--- a/client/src/contexts/chatContext.js
+++ b/client/src/contexts/chatContext.js
@@ -22,10 +22,24 @@ export function ChatProvider({ children }) {
     })
   }, [chatData])
 
+  const getConvName = (conversation) => {
+    if (conversation.isDM) {
+      const [participant1, participant2] = conversation.participants
+      if (participant1._id === chatData._id) { // is self
+        return participant2.username
+      }
+      return participant1.username
+    }
+    return conversation.name
+  }
+
   useEffect(() => {
     socket.initConnection()
     socket.emitJoinChat()
     socket.onChatJoined(user => {
+      user.conversations.forEach(conversation => {
+        conversation.name = getConvName(conversation)
+      })
       setChatData(user)
       setCurrentConversation(user.conversations[0])
       setIsLoading(false)
@@ -46,7 +60,7 @@ export function ChatProvider({ children }) {
     socket.socketRef.current.on('new-conversation', conversation => {
       setChatData(prevChatData => {
         const chatDataDraft = JSON.parse(JSON.stringify(prevChatData))
-        chatDataDraft.conversations.push(conversation)
+        chatDataDraft.conversations.push({...conversation, name: getConvName(conversation)})
         return chatDataDraft
       })
     })


### PR DESCRIPTION
Conversation name was being computed on click, which resulted in it being empty on first load.
Now conversation name is computed when data is fetched instead of on click, fixing the issue #11 .