### PR TITLE
Fix conversation name issue

### DIFF
--- a/client/src/components/SidebarUser.js
+++ b/client/src/components/SidebarUser.js
@@ -21,10 +21,7 @@ export default function SidebarUser({ user, setTab, shouldOpenSidebar, setShould
         if ((participant1._id === chatData._id && participant2._id === user._id)
             || (participant1._id === user._id && participant2._id === chatData._id)) {
           setTab('conversations')
-          setCurrentConversation({
-            ...conversation,
-            name: participant1._id === chatData._id ? participant2.username : participant1.username
-          })
+          setCurrentConversation(conversation)
           return
         }
       }
@@ -41,6 +38,7 @@ export default function SidebarUser({ user, setTab, shouldOpenSidebar, setShould
       // setCurrentConversation here
       setChatData(prevChatData => {
         const chatDataDraft = JSON.parse(JSON.stringify(prevChatData))
+        conversation.name = user.username // other user
         chatDataDraft.conversations.push(conversation)
         const getLastElem = arr => arr[arr.length - 1]
         setCurrentConversation(getLastElem(chatDataDraft.conversations))

--- a/client/src/contexts/chatContext.js
+++ b/client/src/contexts/chatContext.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, createContext, useContext } from 'react'
 import { useSocket } from './socketContext'
+import { UserProvider, useUser } from './userContext'
 
 
 const chatContext = createContext()
@@ -9,7 +10,8 @@ export function ChatProvider({ children }) {
   const [chatData, setChatData] = useState({conversations: []})
   const [currentConversation, setCurrentConversation] = useState({name: '', messages: []})
   const socket = useSocket()
-  console.log(currentConversation)
+  const { userID } = useUser()
+  //console.log(currentConversation)
 
   // Necessary to update the object reference
   // currentConversation references the chatData.conversations[?] object
@@ -23,9 +25,11 @@ export function ChatProvider({ children }) {
   }, [chatData])
 
   const getConvName = (conversation) => {
+    console.log(conversation)
+    console.log(chatData._id)
     if (conversation.isDM) {
       const [participant1, participant2] = conversation.participants
-      if (participant1._id === chatData._id) { // is self
+      if (participant1._id === userID) { // is self
         return participant2.username
       }
       return participant1.username
@@ -39,6 +43,7 @@ export function ChatProvider({ children }) {
     socket.onChatJoined(user => {
       user.conversations.forEach(conversation => {
         conversation.name = getConvName(conversation)
+        console.log(conversation.name)
       })
       setChatData(user)
       setCurrentConversation(user.conversations.find(conv => conv.name === 'General'))
@@ -58,6 +63,7 @@ export function ChatProvider({ children }) {
     })
 
     socket.socketRef.current.on('new-conversation', conversation => {
+      console.log(conversation)
       setChatData(prevChatData => {
         const chatDataDraft = JSON.parse(JSON.stringify(prevChatData))
         chatDataDraft.conversations.push({...conversation, name: getConvName(conversation)})

--- a/server/src/io.js
+++ b/server/src/io.js
@@ -29,6 +29,9 @@ const init = (server, options) => {
   io.on('connection', socket => {
     //console.log('connectin: ', socket.request.session)
     const userID = socket.request.session.userid
+
+    // !!!!! crashes on start when user connects to fast !!!!!
+
     // handle session if (!session) res.redirect()
     // join all rooms on reconnect
     // prevents lost rooms on server restart


### PR DESCRIPTION
Fixed conversation name issue.
Reason: Still using `chatData._id` as the client id and not the new `userID `from the `userContext`