### PR TITLE
#48 Fix message sizing issue

### DIFF
--- a/client/src/components/Message.js
+++ b/client/src/components/Message.js
@@ -38,7 +38,7 @@ export default function Message({message}) {
       textAlign: fromSelf ? 'right' : 'left',
     }}>
       <Typography variant="body1">{ sender.username }</Typography>
-      <Typography fontWeight="300" variant="body2" sx={{
+      <Typography display="inline-block" fontWeight="300" variant="body2" sx={{
         backgroundColor: 'primary.main',
         color: 'primary.contrastText',
         borderRadius: '10px',


### PR DESCRIPTION
Fixed message sizing issue resulted from Typography component having `display: block;` by default